### PR TITLE
Exibir Harami de Alta no gráfico

### DIFF
--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -39,15 +39,18 @@
                 candlestickSeries = chart.addCandlestickSeries({
                     upColor: '#26A69A',
                     downColor: '#EF5350',
-                    borderVisible: false,
+                    borderUpColor: '#26A69A',
+                    borderDownColor: '#EF5350',
                     wickUpColor: '#26A69A',
                     wickDownColor: '#EF5350'
                 });
             } else if (typeof chart.addSeries === 'function') {
-                candlestickSeries = chart.addSeries('Candlestick', {
+                candlestickSeries = chart.addSeries({
+                    type: 'Candlestick',
                     upColor: '#26A69A',
                     downColor: '#EF5350',
-                    borderVisible: false,
+                    borderUpColor: '#26A69A',
+                    borderDownColor: '#EF5350',
                     wickUpColor: '#26A69A',
                     wickDownColor: '#EF5350'
                 });

--- a/app/src/main/assets/chart.html
+++ b/app/src/main/assets/chart.html
@@ -34,18 +34,27 @@
                 timeScale: { timeVisible: true, secondsVisible: false }
             });
             console.log("Chart created:", chart !== null && typeof chart === 'object');
-            console.log("Chart has addCandlestickSeries:", typeof chart.addCandlestickSeries === 'function');
-            console.log("Chart has addSeries:", typeof chart.addSeries === 'function');
-            console.log("LightweightCharts.CandlestickSeries available:", typeof LightweightCharts.CandlestickSeries !== 'undefined');
-
-            console.log("Adding candlestick series using addSeries...");
-            candlestickSeries = chart.addSeries(LightweightCharts.CandlestickSeries, {
-                upColor: '#26A69A',
-                downColor: '#EF5350',
-                borderVisible: false,
-                wickUpColor: '#26A69A',
-                wickDownColor: '#EF5350'
-            });
+            console.log("Initializing candlestick series...");
+            if (typeof chart.addCandlestickSeries === 'function') {
+                candlestickSeries = chart.addCandlestickSeries({
+                    upColor: '#26A69A',
+                    downColor: '#EF5350',
+                    borderVisible: false,
+                    wickUpColor: '#26A69A',
+                    wickDownColor: '#EF5350'
+                });
+            } else if (typeof chart.addSeries === 'function') {
+                candlestickSeries = chart.addSeries('Candlestick', {
+                    upColor: '#26A69A',
+                    downColor: '#EF5350',
+                    borderVisible: false,
+                    wickUpColor: '#26A69A',
+                    wickDownColor: '#EF5350'
+                });
+            } else {
+                console.error('No method available to add candlestick series');
+                return;
+            }
 
             console.log("Chart initialized successfully");
             AndroidInterface.chartInitialized();
@@ -79,6 +88,24 @@
             console.log("Chart updated with data, count:", finalData.length);
         } catch (e) {
             console.error("Error updating chart:", e);
+        }
+    };
+
+    window.updateMarkers = function(jsonData) {
+        if (!chart || !candlestickSeries) {
+            console.error("Chart not initialized. Call initializeChart first.");
+            return;
+        }
+        try {
+            const markers = JSON.parse(jsonData);
+            if (typeof candlestickSeries.setMarkers === 'function') {
+                candlestickSeries.setMarkers(markers);
+                console.log("Markers updated, count:", markers.length);
+            } else {
+                console.warn('setMarkers not supported by candlestickSeries');
+            }
+        } catch (e) {
+            console.error("Error updating markers:", e);
         }
     };
 

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/CandlestickRepository.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/CandlestickRepository.kt
@@ -123,7 +123,7 @@ class CandlestickRepository(
                 val isContained = current.open > previous.close && current.close < previous.open
 
                 if (isBullish && isBearish && isContained) {
-                    haramiCandles.add(current)
+                    // Marca apenas a primeira vela do padrão
                     haramiCandles.add(previous)
                 }
             }


### PR DESCRIPTION
## Summary
- detect only the first candle of Bullish Harami patterns
- expose pattern data in `ChartDetailScreen` and forward as markers to the WebView
- enable JS in `chart.html` to receive and render markers
- provide Kotlin helpers to convert detected candles to marker JSON
- **fix marker rendering by initializing candlestick series correctly and handling missing setMarkers**

## Testing
- `./gradlew test` *(fails: WEB_CLIENT_ID não encontrado no local.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6851269b15ec8332bd2d3ef291dd5f7f