### PR TITLE
Improve Harami Alta candle colors

### DIFF
--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ChartDetailScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ChartDetailScreen.kt
@@ -229,9 +229,17 @@ fun List<Candlestick>.toJsonArray(highlightTimes: Set<Long> = emptySet()): Strin
             put("close", item.close)
             put("volume", item.volume ?: 0)
             if (item.time in highlightTimes) {
-                put("color", "#0000FF")
-                put("wickColor", "#0000FF")
-                put("borderColor", "#0000FF")
+                if (item.close > item.open) {
+                    // Bullish candle of the Harami pattern - white body with blue borders
+                    put("color", "#FFFFFF")
+                    put("wickColor", "#0000FF")
+                    put("borderColor", "#0000FF")
+                } else {
+                    // Bearish candle remains solid blue
+                    put("color", "#0000FF")
+                    put("wickColor", "#0000FF")
+                    put("borderColor", "#0000FF")
+                }
             }
         }
         jsonArray.put(jsonObject)


### PR DESCRIPTION
## Summary
- differentiate candles in highlighted Harami Alta pattern

## Testing
- `bash gradlew test` *(fails: File google-services.json is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68586eca39f083329d282fe42f34a30c