### PR TITLE
Fetch reliability from Firebase

### DIFF
--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/ScreeningResult.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/ScreeningResult.kt
@@ -6,7 +6,7 @@ data class ScreeningResult(
     val pattern: PatternItem,
     val asset: AssetItem,
     val timeframe: TimeframeItem,
-    val reliability: String = "★★★",
-    val indication: String = "Reversão Alta",
+    val reliability: String,
+    val indication: String,
     val indicationIcon: Int = R.drawable.ic_up_arrow
 )

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/viewmodel/ScreeningViewModel.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/viewmodel/ScreeningViewModel.kt
@@ -84,13 +84,15 @@ class ScreeningViewModel(
                         }
                         Log.d("ScreeningViewModel", "Detectados ${patternsDetected.size} padrões Harami de Alta para ${asset.ticker}-${timeframe.value}")
                         if (patternsDetected.isNotEmpty()) {
+                            val reliabilityText = pattern.getLocalized("reliability")
+                            val reliabilityStars = convertReliabilityToStars(reliabilityText)
                             results.add(
                                 ScreeningResult(
                                     pattern = pattern,
                                     asset = asset,
                                     timeframe = timeframe,
-                                    reliability = "★★★",
-                                    indication = "Reversão Alta",
+                                    reliability = reliabilityStars,
+                                    indication = pattern.getLocalized("indication"),
                                     indicationIcon = br.com.rodorush.chartpatterntracker.R.drawable.ic_up_arrow
                                 )
                             )
@@ -106,6 +108,15 @@ class ScreeningViewModel(
             }
             Log.d("ScreeningViewModel", "startScreening concluído com ${results.size} resultados")
             _shouldRefresh.value = false
+        }
+    }
+
+    private fun convertReliabilityToStars(reliability: String): String {
+        return when (reliability.lowercase()) {
+            "baixa" -> "★"
+            "média", "media" -> "★★"
+            "alta" -> "★★★"
+            else -> reliability
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove hardcoded reliability and indication from `ScreeningResult`
- derive reliability and indication in `ScreeningViewModel`
- convert Portuguese reliability values to star ratings

## Testing
- `sh gradlew test --no-daemon` *(fails: Missing '}' - after fix runs but build incomplete due to env)*

------
https://chatgpt.com/codex/tasks/task_e_6860554bee10833294db588f7b6db76c