### PR TITLE
Use resource strings for timeframes

### DIFF
--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/TimeFrameItem.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/TimeFrameItem.kt
@@ -1,29 +1,32 @@
 package br.com.rodorush.chartpatterntracker.model
 
-data class TimeframeItem(val name: String, val value: String) {
+import androidx.annotation.StringRes
+import br.com.rodorush.chartpatterntracker.R
+
+data class TimeframeItem(@StringRes val nameRes: Int, val value: String) {
     companion object {
         val availableTimeframes = listOf(
-            TimeframeItem("1 Minuto", "1m"),
-            TimeframeItem("2 Minutos", "2m"),
-            TimeframeItem("3 Minutos", "3m"),
-            TimeframeItem("4 Minutos", "4m"),
-            TimeframeItem("5 Minutos", "5m"),
-            TimeframeItem("6 Minutos", "6m"),
-            TimeframeItem("10 Minutos", "10m"),
-            TimeframeItem("12 Minutos", "12m"),
-            TimeframeItem("15 Minutos", "15m"),
-            TimeframeItem("20 Minutos", "20m"),
-            TimeframeItem("30 Minutos", "30m"),
-            TimeframeItem("1 Hora", "1h"),
-            TimeframeItem("2 Horas", "2h"),
-            TimeframeItem("3 Horas", "3h"),
-            TimeframeItem("4 Horas", "4h"),
-            TimeframeItem("6 Horas", "6h"),
-            TimeframeItem("8 Horas", "8h"),
-            TimeframeItem("12 Horas", "12h"),
-            TimeframeItem("Diário", "1d"),
-            TimeframeItem("Semanal", "1w"),
-            TimeframeItem("Mensal", "1M")
+            TimeframeItem(R.string.timeframe_1m, "1m"),
+            TimeframeItem(R.string.timeframe_2m, "2m"),
+            TimeframeItem(R.string.timeframe_3m, "3m"),
+            TimeframeItem(R.string.timeframe_4m, "4m"),
+            TimeframeItem(R.string.timeframe_5m, "5m"),
+            TimeframeItem(R.string.timeframe_6m, "6m"),
+            TimeframeItem(R.string.timeframe_10m, "10m"),
+            TimeframeItem(R.string.timeframe_12m, "12m"),
+            TimeframeItem(R.string.timeframe_15m, "15m"),
+            TimeframeItem(R.string.timeframe_20m, "20m"),
+            TimeframeItem(R.string.timeframe_30m, "30m"),
+            TimeframeItem(R.string.timeframe_1h, "1h"),
+            TimeframeItem(R.string.timeframe_2h, "2h"),
+            TimeframeItem(R.string.timeframe_3h, "3h"),
+            TimeframeItem(R.string.timeframe_4h, "4h"),
+            TimeframeItem(R.string.timeframe_6h, "6h"),
+            TimeframeItem(R.string.timeframe_8h, "8h"),
+            TimeframeItem(R.string.timeframe_12h, "12h"),
+            TimeframeItem(R.string.timeframe_1d, "1d"),
+            TimeframeItem(R.string.timeframe_1w, "1w"),
+            TimeframeItem(R.string.timeframe_1mo, "1M")
         )
     }
 }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ScreeningResultsScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ScreeningResultsScreen.kt
@@ -152,7 +152,7 @@ fun ScreeningResultsScreen(
 
                                 Column(modifier = Modifier.weight(1f)) {
                                     Text(
-                                        text = result.timeframe.name,
+                                        text = stringResource(result.timeframe.nameRes),
                                         style = MaterialTheme.typography.bodyMedium
                                     )
                                     Text(

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectTimeFrameScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectTimeFrameScreen.kt
@@ -165,7 +165,7 @@ fun SelectTimeframesScreen(
                             }
                         )
                         Text(
-                            text = timeframe.name,
+                            text = stringResource(timeframe.nameRes),
                             modifier = Modifier.weight(1f)
                         )
                     }

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -52,4 +52,25 @@
     <string name="data_source">Data Source</string>
     <string name="api_key">API key</string>
     <string name="apply">Apply</string>
+    <string name="timeframe_1m">1 Minute</string>
+    <string name="timeframe_2m">2 Minutes</string>
+    <string name="timeframe_3m">3 Minutes</string>
+    <string name="timeframe_4m">4 Minutes</string>
+    <string name="timeframe_5m">5 Minutes</string>
+    <string name="timeframe_6m">6 Minutes</string>
+    <string name="timeframe_10m">10 Minutes</string>
+    <string name="timeframe_12m">12 Minutes</string>
+    <string name="timeframe_15m">15 Minutes</string>
+    <string name="timeframe_20m">20 Minutes</string>
+    <string name="timeframe_30m">30 Minutes</string>
+    <string name="timeframe_1h">1 Hour</string>
+    <string name="timeframe_2h">2 Hours</string>
+    <string name="timeframe_3h">3 Hours</string>
+    <string name="timeframe_4h">4 Hours</string>
+    <string name="timeframe_6h">6 Hours</string>
+    <string name="timeframe_8h">8 Hours</string>
+    <string name="timeframe_12h">12 Hours</string>
+    <string name="timeframe_1d">Daily</string>
+    <string name="timeframe_1w">Weekly</string>
+    <string name="timeframe_1mo">Monthly</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -52,4 +52,25 @@
     <string name="data_source">Fuente de datos</string>
     <string name="api_key">Clave de API</string>
     <string name="apply">Aplicar</string>
+    <string name="timeframe_1m">1 Minuto</string>
+    <string name="timeframe_2m">2 Minutos</string>
+    <string name="timeframe_3m">3 Minutos</string>
+    <string name="timeframe_4m">4 Minutos</string>
+    <string name="timeframe_5m">5 Minutos</string>
+    <string name="timeframe_6m">6 Minutos</string>
+    <string name="timeframe_10m">10 Minutos</string>
+    <string name="timeframe_12m">12 Minutos</string>
+    <string name="timeframe_15m">15 Minutos</string>
+    <string name="timeframe_20m">20 Minutos</string>
+    <string name="timeframe_30m">30 Minutos</string>
+    <string name="timeframe_1h">1 Hora</string>
+    <string name="timeframe_2h">2 Horas</string>
+    <string name="timeframe_3h">3 Horas</string>
+    <string name="timeframe_4h">4 Horas</string>
+    <string name="timeframe_6h">6 Horas</string>
+    <string name="timeframe_8h">8 Horas</string>
+    <string name="timeframe_12h">12 Horas</string>
+    <string name="timeframe_1d">Diario</string>
+    <string name="timeframe_1w">Semanal</string>
+    <string name="timeframe_1mo">Mensual</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -52,4 +52,25 @@
     <string name="data_source">Fonte de Dados</string>
     <string name="api_key">Chave da API</string>
     <string name="apply">Aplicar</string>
+    <string name="timeframe_1m">1 Minuto</string>
+    <string name="timeframe_2m">2 Minutos</string>
+    <string name="timeframe_3m">3 Minutos</string>
+    <string name="timeframe_4m">4 Minutos</string>
+    <string name="timeframe_5m">5 Minutos</string>
+    <string name="timeframe_6m">6 Minutos</string>
+    <string name="timeframe_10m">10 Minutos</string>
+    <string name="timeframe_12m">12 Minutos</string>
+    <string name="timeframe_15m">15 Minutos</string>
+    <string name="timeframe_20m">20 Minutos</string>
+    <string name="timeframe_30m">30 Minutos</string>
+    <string name="timeframe_1h">1 Hora</string>
+    <string name="timeframe_2h">2 Horas</string>
+    <string name="timeframe_3h">3 Horas</string>
+    <string name="timeframe_4h">4 Horas</string>
+    <string name="timeframe_6h">6 Horas</string>
+    <string name="timeframe_8h">8 Horas</string>
+    <string name="timeframe_12h">12 Horas</string>
+    <string name="timeframe_1d">Diário</string>
+    <string name="timeframe_1w">Semanal</string>
+    <string name="timeframe_1mo">Mensal</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,4 +51,25 @@
     <string name="data_source">Fonte de Dados</string>
     <string name="api_key">Chave da API</string>
     <string name="apply">Aplicar</string>
+    <string name="timeframe_1m">1 Minuto</string>
+    <string name="timeframe_2m">2 Minutos</string>
+    <string name="timeframe_3m">3 Minutos</string>
+    <string name="timeframe_4m">4 Minutos</string>
+    <string name="timeframe_5m">5 Minutos</string>
+    <string name="timeframe_6m">6 Minutos</string>
+    <string name="timeframe_10m">10 Minutos</string>
+    <string name="timeframe_12m">12 Minutos</string>
+    <string name="timeframe_15m">15 Minutos</string>
+    <string name="timeframe_20m">20 Minutos</string>
+    <string name="timeframe_30m">30 Minutos</string>
+    <string name="timeframe_1h">1 Hora</string>
+    <string name="timeframe_2h">2 Horas</string>
+    <string name="timeframe_3h">3 Horas</string>
+    <string name="timeframe_4h">4 Horas</string>
+    <string name="timeframe_6h">6 Horas</string>
+    <string name="timeframe_8h">8 Horas</string>
+    <string name="timeframe_12h">12 Horas</string>
+    <string name="timeframe_1d">Diário</string>
+    <string name="timeframe_1w">Semanal</string>
+    <string name="timeframe_1mo">Mensal</string>
 </resources>


### PR DESCRIPTION
## Summary
- add localized strings for timeframe names
- reference timeframe strings in `TimeFrameItem`
- update screens to use localized names

## Testing
- `./gradlew help`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686115b9435883328f22f13e8a732c41