### PR TITLE
Switch kapt to ksp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.org.jetbrains.kotlin.android)
     id("com.google.gms.google-services")
     alias(libs.plugins.compose.compiler)
-    id("org.jetbrains.kotlin.kapt")
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -112,7 +112,7 @@ dependencies {
     implementation(libs.converter.gson)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.room.runtime)
-    kapt(libs.room.compiler)
+    ksp(libs.room.compiler)
     implementation(libs.androidx.room.ktx)
     implementation(libs.firebase.functions.ktx)
     implementation(libs.koin.android)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ retrofit = "3.0.0"
 roomCompiler = "2.7.2"
 roomRuntime = "2.7.2"
 googleServices = "4.4.3"
+ksp = "2.2.0-2.0.2"
 
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
@@ -73,3 +74,4 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary
- replace kapt with ksp for Room code generation
- add ksp plugin definition in version catalog

## Testing
- `./gradlew tasks --all`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6861489612b083328b30833784f1c1a0