### PR TITLE
Implement quote list and chart access

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,7 @@ dependencies {
     implementation(libs.firebase.storage)
     implementation(libs.retrofit)
     implementation(libs.converter.gson)
+    implementation("androidx.compose.material:material-icons-extended")
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.room.runtime)
     ksp(libs.room.compiler)

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/api/BrapiApiService.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/api/BrapiApiService.kt
@@ -1,12 +1,13 @@
 package br.com.rodorush.chartpatterntracker.api
 
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface BrapiApiService {
-    @GET("api/available")
-    suspend fun getAvailableAssets(@Query("token") token: String): AvailableAssetsResponse
+    @GET("api/quote/list")
+    suspend fun getQuoteList(@Header("Authorization") authorization: String): QuoteListResponse
 
     @GET("api/quote/{ticker}")
     suspend fun getHistoricalData(
@@ -16,7 +17,14 @@ interface BrapiApiService {
         @Query("token") token: String
     ): BrapiResponse
 
-    data class AvailableAssetsResponse(
-        val stocks: List<String>
+    data class QuoteListResponse(
+        val stocks: List<StockQuote>
+    )
+
+    data class StockQuote(
+        val stock: String,
+        val name: String,
+        val close: Double?,
+        val change: Double?
     )
 }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/AssetItem.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/AssetItem.kt
@@ -1,3 +1,7 @@
 package br.com.rodorush.chartpatterntracker.model
 
-data class AssetItem(val ticker: String)
+data class AssetItem(
+    val ticker: String,
+    val lastPrice: Double = 0.0,
+    val changePercent: Double = 0.0
+)

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
@@ -72,7 +72,8 @@ fun AppNavHost(
                 SelectAssetsScreen(
                     viewModel = screeningViewModel,
                     onNavigateBack = { navController.popBackStack() },
-                    onNextClick = { navController.navigate(Screen.SelectTimeframes.route) }
+                    onNextClick = { navController.navigate(Screen.SelectTimeframes.route) },
+                    onChartClick = { ticker -> navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d")) }
                 )
             }
         }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectAssetScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectAssetScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
@@ -52,7 +53,8 @@ import android.util.Log
 fun SelectAssetsScreen(
     viewModel: ScreeningViewModel,
     onNavigateBack: () -> Unit = {},
-    onNextClick: () -> Unit = {}
+    onNextClick: () -> Unit = {},
+    onChartClick: (String) -> Unit = {}
 ) {
     val assetsProvider = LocalAssetsProvider.current
     var assets by remember { mutableStateOf<List<AssetItem>>(emptyList()) }
@@ -154,6 +156,19 @@ fun SelectAssetsScreen(
             )
             Spacer(modifier = Modifier.height(16.dp))
 
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Spacer(modifier = Modifier.width(40.dp))
+                Text(text = stringResource(R.string.ticker), modifier = Modifier.weight(1f))
+                Text(text = stringResource(R.string.last_price), modifier = Modifier.width(80.dp))
+                Text(text = stringResource(R.string.change_percent), modifier = Modifier.width(80.dp))
+                Spacer(modifier = Modifier.width(40.dp))
+            }
+
             LazyColumn(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.weight(1f)
@@ -176,6 +191,22 @@ fun SelectAssetsScreen(
                             text = asset.ticker,
                             modifier = Modifier.weight(1f)
                         )
+                        Text(
+                            text = "R$ %.2f".format(asset.lastPrice),
+                            modifier = Modifier.width(80.dp)
+                        )
+                        val changeColor = if (asset.changePercent >= 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                        Text(
+                            text = (if (asset.changePercent >= 0) "+" else "") + "%.2f%%".format(asset.changePercent),
+                            color = changeColor,
+                            modifier = Modifier.width(80.dp)
+                        )
+                        IconButton(onClick = { onChartClick(asset.ticker) }) {
+                            Icon(
+                                imageVector = Icons.Default.ShowChart,
+                                contentDescription = stringResource(R.string.view_chart)
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/util/provider/BrapiAssetsProvider.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/util/provider/BrapiAssetsProvider.kt
@@ -18,8 +18,14 @@ class BrapiAssetsProvider : AssetsProvider {
 
     override suspend fun fetchAssets(onResult: (List<AssetItem>) -> Unit) {
         try {
-            val response = service.getAvailableAssets(token)
-            val assets = response.stocks.map { AssetItem(it) }
+            val response = service.getQuoteList("Bearer $token")
+            val assets = response.stocks.map {
+                AssetItem(
+                    ticker = it.stock,
+                    lastPrice = it.close ?: 0.0,
+                    changePercent = it.change ?: 0.0
+                )
+            }
             onResult(assets)
         } catch (e: Exception) {
             onResult(emptyList())

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/util/provider/mock/MockAssetsProvider.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/util/provider/mock/MockAssetsProvider.kt
@@ -6,10 +6,10 @@ import br.com.rodorush.chartpatterntracker.util.provider.interfaces.AssetsProvid
 class MockAssetsProvider : AssetsProvider {
     override suspend fun fetchAssets(onResult: (List<AssetItem>) -> Unit) {
         val mockAssets = listOf(
-            AssetItem("PETR4"),
-            AssetItem("VALE3"),
-            AssetItem("ITUB4"),
-            AssetItem("BBDC4")
+            AssetItem("PETR4", 38.5, 1.2),
+            AssetItem("VALE3", 62.3, -0.8),
+            AssetItem("ITUB4", 29.1, 0.0),
+            AssetItem("BBDC4", 17.4, 2.3)
         )
         onResult(mockAssets)
     }

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -73,4 +73,8 @@
     <string name="timeframe_1d">Daily</string>
     <string name="timeframe_1w">Weekly</string>
     <string name="timeframe_1mo">Monthly</string>
+    <string name="ticker">Ticker</string>
+    <string name="last_price">Last Price</string>
+    <string name="change_percent">% Change</string>
+    <string name="view_chart">View chart</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -73,4 +73,8 @@
     <string name="timeframe_1d">Diario</string>
     <string name="timeframe_1w">Semanal</string>
     <string name="timeframe_1mo">Mensual</string>
+    <string name="ticker">Ticker</string>
+    <string name="last_price">Último Precio</string>
+    <string name="change_percent">% Variación</string>
+    <string name="view_chart">Ver gráfico</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -73,4 +73,8 @@
     <string name="timeframe_1d">Diário</string>
     <string name="timeframe_1w">Semanal</string>
     <string name="timeframe_1mo">Mensal</string>
+    <string name="ticker">Ticker</string>
+    <string name="last_price">Último Preço</string>
+    <string name="change_percent">% Variação</string>
+    <string name="view_chart">Ver gráfico</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,4 +72,8 @@
     <string name="timeframe_1d">Diário</string>
     <string name="timeframe_1w">Semanal</string>
     <string name="timeframe_1mo">Mensal</string>
+    <string name="ticker">Ticker</string>
+    <string name="last_price">Último Preço</string>
+    <string name="change_percent">% Variação</string>
+    <string name="view_chart">Ver gráfico</string>
 </resources>


### PR DESCRIPTION
## Summary
- fetch available assets from new Brapi endpoint returning quote data
- extend `AssetItem` with price and change
- show price, variation and chart button on SelectAssetScreen
- open chart on icon click
- include icons dependency and new translations

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68639dcb872483329f36527d665a8281