### PR TITLE
Implement Real Time Quotes screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,7 @@ dependencies {
     implementation(libs.play.services.auth)
     implementation(libs.firebase.firestore.ktx)
     implementation(libs.coil.compose)
+    implementation(libs.coil.svg)
     implementation(libs.firebase.storage)
     implementation(libs.retrofit)
     implementation(libs.converter.gson)

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/api/BrapiApiService.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/api/BrapiApiService.kt
@@ -25,6 +25,7 @@ interface BrapiApiService {
         val stock: String,
         val name: String,
         val close: Double?,
-        val change: Double?
+        val change: Double?,
+        val logo: String?
     )
 }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/AssetItem.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/AssetItem.kt
@@ -3,5 +3,6 @@ package br.com.rodorush.chartpatterntracker.model
 data class AssetItem(
     val ticker: String,
     val lastPrice: Double = 0.0,
-    val changePercent: Double = 0.0
+    val changePercent: Double = 0.0,
+    val logo: String = ""
 )

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
@@ -17,6 +17,7 @@ import br.com.rodorush.chartpatterntracker.ui.screen.SelectAssetsScreen
 import br.com.rodorush.chartpatterntracker.ui.screen.SelectChartPatternScreen
 import br.com.rodorush.chartpatterntracker.ui.screen.SelectTimeframesScreen
 import br.com.rodorush.chartpatterntracker.ui.screen.SettingsScreen
+import br.com.rodorush.chartpatterntracker.ui.screen.RealTimeQuotesScreen
 import br.com.rodorush.chartpatterntracker.util.LocalAssetsProvider
 import br.com.rodorush.chartpatterntracker.util.provider.BrapiAssetsProvider
 import br.com.rodorush.chartpatterntracker.viewmodel.ScreeningViewModel
@@ -41,6 +42,9 @@ fun AppNavHost(
             MainScreen(
                 onNavigateToSelectChartPattern = {
                     navController.navigate(Screen.SelectChartPattern.route)
+                },
+                onNavigateToRealTimeQuotes = {
+                    navController.navigate(Screen.RealTimeQuotes.route)
                 },
                 onNavigateToSettings = {
                     navController.navigate(Screen.Settings.route)
@@ -74,6 +78,15 @@ fun AppNavHost(
                     onNavigateBack = { navController.popBackStack() },
                     onNextClick = { navController.navigate(Screen.SelectTimeframes.route) },
                     onChartClick = { ticker -> navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d")) }
+                )
+            }
+        }
+
+        composable(Screen.RealTimeQuotes.route) {
+            CompositionLocalProvider(LocalAssetsProvider provides BrapiAssetsProvider()) {
+                RealTimeQuotesScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onRowClick = { ticker -> navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d")) }
                 )
             }
         }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
@@ -78,7 +78,7 @@ fun AppNavHost(
                     onNavigateBack = { navController.popBackStack() },
                     onNextClick = { navController.navigate(Screen.SelectTimeframes.route) },
                     onChartClick = { ticker ->
-                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d"))
+                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d", false))
                     }
                 )
             }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
@@ -77,7 +77,9 @@ fun AppNavHost(
                     viewModel = screeningViewModel,
                     onNavigateBack = { navController.popBackStack() },
                     onNextClick = { navController.navigate(Screen.SelectTimeframes.route) },
-                    onChartClick = { ticker -> navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d")) }
+                    onChartClick = { ticker ->
+                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d"))
+                    }
                 )
             }
         }
@@ -86,7 +88,9 @@ fun AppNavHost(
             CompositionLocalProvider(LocalAssetsProvider provides BrapiAssetsProvider()) {
                 RealTimeQuotesScreen(
                     onNavigateBack = { navController.popBackStack() },
-                    onRowClick = { ticker -> navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d")) }
+                    onRowClick = { ticker ->
+                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d", false))
+                    }
                 )
             }
         }
@@ -110,23 +114,29 @@ fun AppNavHost(
                 viewModel = screeningViewModel,
                 onNavigateBack = { navController.popBackStack() },
                 onCardClick = { ticker, timeframe ->
-                    navController.navigate("chart_detail/$ticker/$timeframe")
+                    navController.navigate(Screen.ChartDetail.createRoute(ticker, timeframe))
                 }
             )
         }
 
         composable(
-            Screen.ChartDetail.route + "/{ticker}/{timeframe}",
+            Screen.ChartDetail.route + "/{ticker}/{timeframe}?detectPatterns={detectPatterns}",
             arguments = listOf(
                 navArgument("ticker") { type = NavType.StringType },
-                navArgument("timeframe") { type = NavType.StringType }
+                navArgument("timeframe") { type = NavType.StringType },
+                navArgument("detectPatterns") {
+                    type = NavType.BoolType
+                    defaultValue = true
+                }
             )
         ) { backStackEntry ->
             val ticker = backStackEntry.arguments?.getString("ticker") ?: ""
             val timeframe = backStackEntry.arguments?.getString("timeframe") ?: "1d"
+            val detectPatterns = backStackEntry.arguments?.getBoolean("detectPatterns") ?: true
             ChartDetailScreen(
                 ticker = ticker,
                 timeframe = timeframe,
+                detectPatterns = detectPatterns,
                 onNavigateBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/NavigationRoutes.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/NavigationRoutes.kt
@@ -12,5 +12,6 @@ sealed class Screen(val route: String) {
     object ChartDetail : Screen("chart_detail") {
         fun createRoute(ticker: String, timeframe: String) = "chart_detail/$ticker/$timeframe"
     }
+    object RealTimeQuotes : Screen("real_time_quotes")
     object Settings : Screen("settings") // Nova rota para Settings
 }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/NavigationRoutes.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/NavigationRoutes.kt
@@ -10,7 +10,8 @@ sealed class Screen(val route: String) {
     object SelectTimeframes : Screen("select_timeframes")
     object ScreeningResults : Screen("screening_results")
     object ChartDetail : Screen("chart_detail") {
-        fun createRoute(ticker: String, timeframe: String) = "chart_detail/$ticker/$timeframe"
+        fun createRoute(ticker: String, timeframe: String, detectPatterns: Boolean = true) =
+            "chart_detail/$ticker/$timeframe?detectPatterns=$detectPatterns"
     }
     object RealTimeQuotes : Screen("real_time_quotes")
     object Settings : Screen("settings") // Nova rota para Settings

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ChartDetailScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ChartDetailScreen.kt
@@ -46,6 +46,7 @@ import org.koin.androidx.compose.koinViewModel
 fun ChartDetailScreen(
     ticker: String,
     timeframe: String,
+    detectPatterns: Boolean = true,
     onNavigateBack: () -> Unit
 ) {
     val viewModel: ChartViewModel = koinViewModel() // Deixa o Koin fornecer o ViewModel
@@ -64,8 +65,8 @@ fun ChartDetailScreen(
         onNavigateBack()
     }
 
-    LaunchedEffect(ticker, timeframe) {
-        viewModel.fetchData(ticker, "3mo", timeframe)
+    LaunchedEffect(ticker, timeframe, detectPatterns) {
+        viewModel.fetchData(ticker, "3mo", timeframe, detectPatterns)
     }
 
     LaunchedEffect(candlestickData, patternsData, isChartInitialized) {

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/MainScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/MainScreen.kt
@@ -36,6 +36,7 @@ import br.com.rodorush.chartpatterntracker.util.provider.mock.MockAuthProvider
 @Composable
 fun MainScreen(
     onNavigateToSelectChartPattern: () -> Unit,
+    onNavigateToRealTimeQuotes: () -> Unit,
     onNavigateToSettings: () -> Unit = {},
     onLogout: () -> Unit
 ) {
@@ -78,13 +79,7 @@ fun MainScreen(
                     Toast.LENGTH_SHORT
                 ).show()
             })
-        ButtonMenuItem(R.string.real_time_quotes, onClick = {
-            Toast.makeText(
-                context,
-                R.string.real_time_quotes,
-                Toast.LENGTH_SHORT
-            ).show()
-        })
+        ButtonMenuItem(R.string.real_time_quotes, onClick = onNavigateToRealTimeQuotes)
         ButtonMenuItem(R.string.technical_indicators, onClick = {
             Toast.makeText(
                 context,
@@ -131,6 +126,7 @@ fun MainScreenPreview() {
             ChartPatternTrackerTheme {
                 MainScreen(
                     onNavigateToSelectChartPattern = {},
+                    onNavigateToRealTimeQuotes = {},
                     onLogout = {})
             }
         }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/RealTimeQuotesScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/RealTimeQuotesScreen.kt
@@ -1,0 +1,165 @@
+package br.com.rodorush.chartpatterntracker.ui.screen
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import br.com.rodorush.chartpatterntracker.R
+import br.com.rodorush.chartpatterntracker.model.AssetItem
+import br.com.rodorush.chartpatterntracker.util.LocalAssetsProvider
+import coil.compose.AsyncImage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RealTimeQuotesScreen(
+    onNavigateBack: () -> Unit = {},
+    onRowClick: (String) -> Unit = {}
+) {
+    val assetsProvider = LocalAssetsProvider.current
+    var assets by remember { mutableStateOf<List<AssetItem>>(emptyList()) }
+    var isLoaded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        if (!isLoaded) {
+            assetsProvider.fetchAssets { loadedAssets ->
+                assets = loadedAssets
+                isLoaded = true
+            }
+        }
+    }
+
+    var searchText by remember { mutableStateOf("") }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(R.string.back)
+                            )
+                        }
+                        IconButton(onClick = { /* profile */ }) {
+                            Icon(
+                                imageVector = Icons.Default.Person,
+                                contentDescription = stringResource(R.string.profile)
+                            )
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        TextField(
+                            value = searchText,
+                            onValueChange = { searchText = it },
+                            modifier = Modifier.weight(1f),
+                            placeholder = { Text(stringResource(R.string.search_assets)) },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Default.Search,
+                                    contentDescription = stringResource(R.string.search)
+                                )
+                            }
+                        )
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .padding(16.dp)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(R.string.real_time_quotes),
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Spacer(modifier = Modifier.width(40.dp))
+                Text(text = stringResource(R.string.ticker), modifier = Modifier.weight(1f))
+                Text(text = stringResource(R.string.last_price), modifier = Modifier.width(80.dp))
+                Text(text = stringResource(R.string.change_percent), modifier = Modifier.width(80.dp))
+                Spacer(modifier = Modifier.width(40.dp))
+            }
+
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.weight(1f)
+            ) {
+                val filtered = assets.filter { it.ticker.contains(searchText, ignoreCase = true) }
+                items(filtered) { asset ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onRowClick(asset.ticker) }
+                            .padding(horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        AsyncImage(
+                            model = asset.logo,
+                            contentDescription = stringResource(R.string.logo),
+                            modifier = Modifier.width(40.dp)
+                        )
+                        Text(
+                            text = asset.ticker,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Text(
+                            text = "R$ %.2f".format(asset.lastPrice),
+                            modifier = Modifier.width(80.dp)
+                        )
+                        val changeColor = if (asset.changePercent >= 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                        Text(
+                            text = (if (asset.changePercent >= 0) "+" else "") + "%.2f%%".format(asset.changePercent),
+                            color = changeColor,
+                            modifier = Modifier.width(80.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/RealTimeQuotesScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/RealTimeQuotesScreen.kt
@@ -38,7 +38,10 @@ import androidx.compose.ui.unit.dp
 import br.com.rodorush.chartpatterntracker.R
 import br.com.rodorush.chartpatterntracker.model.AssetItem
 import br.com.rodorush.chartpatterntracker.util.LocalAssetsProvider
+import androidx.compose.ui.platform.LocalContext
 import coil.compose.AsyncImage
+import coil.decode.SvgDecoder
+import coil.request.ImageRequest
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -139,7 +142,10 @@ fun RealTimeQuotesScreen(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         AsyncImage(
-                            model = asset.logo,
+                            model = ImageRequest.Builder(LocalContext.current)
+                                .data(asset.logo)
+                                .decoderFactory(SvgDecoder.Factory())
+                                .build(),
                             contentDescription = stringResource(R.string.logo),
                             modifier = Modifier.width(40.dp)
                         )

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/viewmodel/ChartViewModel.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/viewmodel/ChartViewModel.kt
@@ -72,7 +72,7 @@ class ChartViewModel(
         Log.d("ChartViewModel", "API key definida com sucesso")
     }
 
-    fun fetchData(ticker: String, range: String, interval: String) {
+    fun fetchData(ticker: String, range: String, interval: String, detectPatterns: Boolean = true) {
         if (ticker.isBlank() || interval.isBlank()) {
             Log.e("ChartViewModel", "Ticker ou interval inválidos: ticker=$ticker, interval=$interval")
             _error.value = "Parâmetros inválidos"
@@ -97,12 +97,16 @@ class ChartViewModel(
                         Log.d("ChartViewModel", "Candlesticks completos obtidos: ${fullCandlesticks.size}")
                         if (fullCandlesticks.isNotEmpty()) {
                             _candlestickData.value = fullCandlesticks
-                            val haramiPatterns = repository.detectHaramiAlta(fullCandlesticks)
-                            Log.d(
-                                "ChartViewModel",
-                                "Padrões Harami de Alta detectados: ${haramiPatterns.size}"
-                            )
-                            _patternsData.value = haramiPatterns
+                            if (detectPatterns) {
+                                val haramiPatterns = repository.detectHaramiAlta(fullCandlesticks)
+                                Log.d(
+                                    "ChartViewModel",
+                                    "Padrões Harami de Alta detectados: ${haramiPatterns.size}"
+                                )
+                                _patternsData.value = haramiPatterns
+                            } else {
+                                _patternsData.value = emptyList()
+                            }
                         } else {
                             Log.w("ChartViewModel", "Nenhum candlestick completo retornado para $ticker")
                             _candlestickData.value = emptyList()

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/util/provider/BrapiAssetsProvider.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/util/provider/BrapiAssetsProvider.kt
@@ -23,7 +23,8 @@ class BrapiAssetsProvider : AssetsProvider {
                 AssetItem(
                     ticker = it.stock,
                     lastPrice = it.close ?: 0.0,
-                    changePercent = it.change ?: 0.0
+                    changePercent = it.change ?: 0.0,
+                    logo = it.logo ?: ""
                 )
             }
             onResult(assets)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "8.11.0"
 appcompat = "1.7.1"
 coilCompose = "2.7.0"
+coilSvg = "2.7.0"
 converterGson = "3.0.0"
 firebaseAnalyticsKtx = "22.5.0"
 firebaseAppcheckPlayintegrity = "18.0.0"
@@ -39,6 +40,7 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
+coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coilSvg" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics-ktx", version.ref = "firebaseAnalyticsKtx" }


### PR DESCRIPTION
## Summary
- extend AssetItem to include logo url
- expose logo from Brapi API and map it in assets provider
- implement `RealTimeQuotesScreen` showing logo and opening chart when an asset row is clicked
- update main menu and navigation routes to include the new screen

## Testing
- `bash ./gradlew test --quiet` *(fails: installing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6864f0c964848332a48720c88d39ebeb