### PR TITLE
Add extensible candlestick pattern detection

### DIFF
--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/BullishEngulfingDetector.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/BullishEngulfingDetector.kt
@@ -1,0 +1,22 @@
+package br.com.rodorush.chartpatterntracker.model.pattern
+
+import br.com.rodorush.chartpatterntracker.model.Candlestick
+import br.com.rodorush.chartpatterntracker.model.PatternOccurrence
+
+class BullishEngulfingDetector : PatternDetector {
+    override fun detect(candlesticks: List<Candlestick>): List<PatternOccurrence> {
+        val occurrences = mutableListOf<PatternOccurrence>()
+        if (candlesticks.size < 2) return occurrences
+        for (i in 1 until candlesticks.size) {
+            val current = candlesticks[i]
+            val previous = candlesticks[i - 1]
+            val prevBearish = previous.open > previous.close
+            val currBullish = current.close > current.open
+            val engulfs = current.open <= previous.close && current.close >= previous.open
+            if (prevBearish && currBullish && engulfs) {
+                occurrences.add(PatternOccurrence(listOf(previous, current)))
+            }
+        }
+        return occurrences
+    }
+}

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/HaramiAltaDetector.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/HaramiAltaDetector.kt
@@ -1,0 +1,22 @@
+package br.com.rodorush.chartpatterntracker.model.pattern
+
+import br.com.rodorush.chartpatterntracker.model.Candlestick
+import br.com.rodorush.chartpatterntracker.model.PatternOccurrence
+
+class HaramiAltaDetector : PatternDetector {
+    override fun detect(candlesticks: List<Candlestick>): List<PatternOccurrence> {
+        val occurrences = mutableListOf<PatternOccurrence>()
+        if (candlesticks.size < 2) return occurrences
+        for (i in 1 until candlesticks.size) {
+            val current = candlesticks[i]
+            val previous = candlesticks[i - 1]
+            val isBullish = current.close > current.open
+            val isBearish = previous.open > previous.close
+            val isContained = current.open > previous.close && current.close < previous.open
+            if (isBullish && isBearish && isContained) {
+                occurrences.add(PatternOccurrence(listOf(previous, current)))
+            }
+        }
+        return occurrences
+    }
+}

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/PatternDetector.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/PatternDetector.kt
@@ -1,0 +1,8 @@
+package br.com.rodorush.chartpatterntracker.model.pattern
+
+import br.com.rodorush.chartpatterntracker.model.Candlestick
+import br.com.rodorush.chartpatterntracker.model.PatternOccurrence
+
+interface PatternDetector {
+    fun detect(candlesticks: List<Candlestick>): List<PatternOccurrence>
+}

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/PatternDetectorRegistry.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/PatternDetectorRegistry.kt
@@ -1,0 +1,20 @@
+package br.com.rodorush.chartpatterntracker.model.pattern
+
+object PatternDetectorRegistry {
+    private val detectors = mutableMapOf<String, PatternDetector>()
+
+    init {
+        // Harami de Alta - document ID 48
+        register("48", HaramiAltaDetector())
+        // Example: Bullish Engulfing pattern with placeholder ID "49"
+        register("49", BullishEngulfingDetector())
+    }
+
+    fun register(id: String, detector: PatternDetector) {
+        detectors[id] = detector
+    }
+
+    fun get(id: String): PatternDetector? = detectors[id]
+
+    fun registeredIds(): List<String> = detectors.keys.toList()
+}

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
@@ -78,7 +78,7 @@ fun AppNavHost(
                     onNavigateBack = { navController.popBackStack() },
                     onNextClick = { navController.navigate(Screen.SelectTimeframes.route) },
                     onChartClick = { ticker ->
-                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d", false))
+                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d", null, false))
                     }
                 )
             }
@@ -89,7 +89,7 @@ fun AppNavHost(
                 RealTimeQuotesScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onRowClick = { ticker ->
-                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d", false))
+                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d", null, false))
                     }
                 )
             }
@@ -113,17 +113,18 @@ fun AppNavHost(
             ScreeningResultsScreen(
                 viewModel = screeningViewModel,
                 onNavigateBack = { navController.popBackStack() },
-                onCardClick = { ticker, timeframe ->
-                    navController.navigate(Screen.ChartDetail.createRoute(ticker, timeframe))
+                onCardClick = { ticker, timeframe, patternId ->
+                    navController.navigate(Screen.ChartDetail.createRoute(ticker, timeframe, patternId))
                 }
             )
         }
 
         composable(
-            Screen.ChartDetail.route + "/{ticker}/{timeframe}?detectPatterns={detectPatterns}",
+            Screen.ChartDetail.route + "/{ticker}/{timeframe}?patternId={patternId}&detectPatterns={detectPatterns}",
             arguments = listOf(
                 navArgument("ticker") { type = NavType.StringType },
                 navArgument("timeframe") { type = NavType.StringType },
+                navArgument("patternId") { type = NavType.StringType; defaultValue = "" },
                 navArgument("detectPatterns") {
                     type = NavType.BoolType
                     defaultValue = true
@@ -132,10 +133,12 @@ fun AppNavHost(
         ) { backStackEntry ->
             val ticker = backStackEntry.arguments?.getString("ticker") ?: ""
             val timeframe = backStackEntry.arguments?.getString("timeframe") ?: "1d"
+            val patternId = backStackEntry.arguments?.getString("patternId")?.takeIf { it.isNotEmpty() }
             val detectPatterns = backStackEntry.arguments?.getBoolean("detectPatterns") ?: true
             ChartDetailScreen(
                 ticker = ticker,
                 timeframe = timeframe,
+                patternId = patternId,
                 detectPatterns = detectPatterns,
                 onNavigateBack = { navController.popBackStack() }
             )

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/NavigationRoutes.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/NavigationRoutes.kt
@@ -10,8 +10,15 @@ sealed class Screen(val route: String) {
     object SelectTimeframes : Screen("select_timeframes")
     object ScreeningResults : Screen("screening_results")
     object ChartDetail : Screen("chart_detail") {
-        fun createRoute(ticker: String, timeframe: String, detectPatterns: Boolean = true) =
-            "chart_detail/$ticker/$timeframe?detectPatterns=$detectPatterns"
+        fun createRoute(
+            ticker: String,
+            timeframe: String,
+            patternId: String? = null,
+            detectPatterns: Boolean = true
+        ): String {
+            val idPart = patternId ?: ""
+            return "chart_detail/$ticker/$timeframe?patternId=$idPart&detectPatterns=$detectPatterns"
+        }
     }
     object RealTimeQuotes : Screen("real_time_quotes")
     object Settings : Screen("settings") // Nova rota para Settings

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ScreeningResultsScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ScreeningResultsScreen.kt
@@ -51,7 +51,7 @@ import br.com.rodorush.chartpatterntracker.viewmodel.ScreeningViewModel
 fun ScreeningResultsScreen(
     viewModel: ScreeningViewModel = viewModel(),
     onNavigateBack: () -> Unit = {},
-    onCardClick: (String, String) -> Unit = { _, _ -> }
+    onCardClick: (String, String, String) -> Unit = { _, _, _ -> }
 ) {
     Log.d("ScreeningResultsScreen", "Tela ScreeningResultsScreen carregada")
     // Coleta os resultados do ViewModel
@@ -121,7 +121,7 @@ fun ScreeningResultsScreen(
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
             } else if (screeningResults.isEmpty()) {
                 Text(
-                    text = "Nenhum padrão Harami de Alta encontrado.",
+                    text = stringResource(id = R.string.no_patterns_found),
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.align(Alignment.CenterHorizontally)
                 )
@@ -134,7 +134,7 @@ fun ScreeningResultsScreen(
                         Card(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable { onCardClick(result.asset.ticker, result.timeframe.value) }
+                                .clickable { onCardClick(result.asset.ticker, result.timeframe.value, result.pattern.id) }
                         ) {
                             Row(
                                 modifier = Modifier
@@ -195,6 +195,6 @@ fun ScreeningResultsScreen(
 @Composable
 fun ScreeningResultsScreenPreview() {
     ChartPatternTrackerTheme {
-        ScreeningResultsScreen()
+        ScreeningResultsScreen(onCardClick = { _, _, _ -> })
     }
 }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/viewmodel/ChartViewModel.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/viewmodel/ChartViewModel.kt
@@ -26,8 +26,8 @@ class ChartViewModel(
     private val _candlestickData = MutableStateFlow<List<Candlestick>>(emptyList())
     val candlestickData: StateFlow<List<Candlestick>> = _candlestickData
 
-    private val _patternsData = MutableStateFlow<List<PatternOccurrence>>(emptyList())
-    val patternsData: StateFlow<List<PatternOccurrence>> = _patternsData
+    private val _patternsData = MutableStateFlow<Map<String, List<PatternOccurrence>>>(emptyMap())
+    val patternsData: StateFlow<Map<String, List<PatternOccurrence>>> = _patternsData
 
     private val _currentSource = MutableStateFlow<AssetDataSource>(BrapiDataSource())
     val currentSource: StateFlow<AssetDataSource> = _currentSource
@@ -72,7 +72,13 @@ class ChartViewModel(
         Log.d("ChartViewModel", "API key definida com sucesso")
     }
 
-    fun fetchData(ticker: String, range: String, interval: String, detectPatterns: Boolean = true) {
+    fun fetchData(
+        ticker: String,
+        range: String,
+        interval: String,
+        detectPatterns: Boolean = true,
+        patternIds: List<String> = listOf("48")
+    ) {
         if (ticker.isBlank() || interval.isBlank()) {
             Log.e("ChartViewModel", "Ticker ou interval inválidos: ticker=$ticker, interval=$interval")
             _error.value = "Parâmetros inválidos"
@@ -98,31 +104,32 @@ class ChartViewModel(
                         if (fullCandlesticks.isNotEmpty()) {
                             _candlestickData.value = fullCandlesticks
                             if (detectPatterns) {
-                                val haramiPatterns = repository.detectHaramiAlta(fullCandlesticks)
+                                val detected = repository.detectPatterns(patternIds, fullCandlesticks)
+                                _patternsData.value = detected
                                 Log.d(
                                     "ChartViewModel",
-                                    "Padrões Harami de Alta detectados: ${haramiPatterns.size}"
+                                    "Padrões detectados: " + detected.map { it.key to it.value.size }
                                 )
-                                _patternsData.value = haramiPatterns
                             } else {
-                                _patternsData.value = emptyList()
+                                _patternsData.value = emptyMap()
                             }
                         } else {
                             Log.w("ChartViewModel", "Nenhum candlestick completo retornado para $ticker")
                             _candlestickData.value = emptyList()
-                            _patternsData.value = emptyList()
+                            _patternsData.value = emptyMap()
                             _error.value = "Falha ao obter dados completos"
                         }
                     }
                 }.onFailure { e ->
                     Log.e("ChartViewModel", "Erro ao obter dados iniciais: ${e.message}", e)
                     _candlestickData.value = emptyList()
-                    _patternsData.value = emptyList()
+                    _patternsData.value = emptyMap()
                     _error.value = e.message ?: "Falha ao buscar dados iniciais"
                 }
             } catch (e: Exception) {
                 Log.e("ChartViewModel", "Erro inesperado em fetchData: ${e.message}", e)
                 _candlestickData.value = emptyList()
+                _patternsData.value = emptyMap()
                 _error.value = e.message ?: "Erro inesperado"
             } finally {
                 _isLoading.value = false

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/viewmodel/ScreeningViewModel.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/viewmodel/ScreeningViewModel.kt
@@ -58,51 +58,51 @@ class ScreeningViewModel(
         viewModelScope.launch {
             _screeningResults.value = emptyList()
             val results = mutableListOf<ScreeningResult>()
-            val pattern = _selectedPatterns.value.firstOrNull { it.id == "48" }
-            if (pattern == null) {
-                Log.w("ScreeningViewModel", "Nenhum padrão Harami de Alta (ID 48) selecionado")
-                return@launch
-            }
-            Log.d("ScreeningViewModel", "Padrão Harami de Alta selecionado: ${pattern.id} - ${pattern.name}")
-
-            for (asset in _selectedAssets.value) {
-                for (timeframe in _selectedTimeframes.value) {
-                    try {
-                        Log.d("ScreeningViewModel", "Chamando fetchData para ticker=${asset.ticker}, timeframe=${timeframe.value}")
-                        val patternsDetected = withTimeoutOrNull(15000L) {
-                            chartViewModel.fetchData(asset.ticker, "3mo", timeframe.value)
-                            chartViewModel.isLoading.first { !it }
-                            chartViewModel.patternsData.first()
-                        }
-                        if (patternsDetected == null) {
-                            Log.e("ScreeningViewModel", "Timeout ao processar ${asset.ticker}-${timeframe.value}")
-                            continue
-                        }
-                        if (chartViewModel.error.value != null) {
-                            Log.e("ScreeningViewModel", "Erro retornado pelo ChartViewModel para ${asset.ticker}-${timeframe.value}: ${chartViewModel.error.value}")
-                            continue
-                        }
-                        Log.d("ScreeningViewModel", "Detectados ${patternsDetected.size} padrões Harami de Alta para ${asset.ticker}-${timeframe.value}")
-                        if (patternsDetected.isNotEmpty()) {
-                            val reliabilityText = pattern.getLocalized("reliability")
-                            val reliabilityStars = convertReliabilityToStars(reliabilityText)
-                            results.add(
-                                ScreeningResult(
-                                    pattern = pattern,
-                                    asset = asset,
-                                    timeframe = timeframe,
-                                    reliability = reliabilityStars,
-                                    indication = pattern.getLocalized("indication"),
-                                    indicationIcon = br.com.rodorush.chartpatterntracker.R.drawable.ic_up_arrow
+            for (pattern in _selectedPatterns.value) {
+                Log.d("ScreeningViewModel", "Processando padrão ${pattern.id}")
+                for (asset in _selectedAssets.value) {
+                    for (timeframe in _selectedTimeframes.value) {
+                        try {
+                            Log.d("ScreeningViewModel", "Chamando fetchData para ticker=${asset.ticker}, timeframe=${timeframe.value}")
+                            val patternsDetected = withTimeoutOrNull(15000L) {
+                                chartViewModel.fetchData(asset.ticker, "3mo", timeframe.value, true, listOf(pattern.id))
+                                chartViewModel.isLoading.first { !it }
+                                chartViewModel.patternsData.first()
+                            }
+                            if (patternsDetected == null) {
+                                Log.e("ScreeningViewModel", "Timeout ao processar ${asset.ticker}-${timeframe.value}")
+                                continue
+                            }
+                            if (chartViewModel.error.value != null) {
+                                Log.e(
+                                    "ScreeningViewModel",
+                                    "Erro retornado pelo ChartViewModel para ${asset.ticker}-${timeframe.value}: ${chartViewModel.error.value}"
                                 )
+                                continue
+                            }
+                            val occurrences = patternsDetected[pattern.id].orEmpty()
+                            Log.d(
+                                "ScreeningViewModel",
+                                "Detectados ${occurrences.size} padrões ${pattern.id} para ${asset.ticker}-${timeframe.value}"
                             )
-                            _screeningResults.value = results.toList()
-                            Log.d("ScreeningViewModel", "Resultado adicionado para ${asset.ticker}-${timeframe.value}")
-                        } else {
-                            Log.d("ScreeningViewModel", "Nenhum padrão Harami de Alta encontrado para ${asset.ticker}-${timeframe.value}")
+                            if (occurrences.isNotEmpty()) {
+                                val reliabilityText = pattern.getLocalized("reliability")
+                                val reliabilityStars = convertReliabilityToStars(reliabilityText)
+                                results.add(
+                                    ScreeningResult(
+                                        pattern = pattern,
+                                        asset = asset,
+                                        timeframe = timeframe,
+                                        reliability = reliabilityStars,
+                                        indication = pattern.getLocalized("indication"),
+                                        indicationIcon = br.com.rodorush.chartpatterntracker.R.drawable.ic_up_arrow
+                                    )
+                                )
+                                _screeningResults.value = results.toList()
+                            }
+                        } catch (e: Exception) {
+                            Log.e("ScreeningViewModel", "Erro ao processar ${asset.ticker}-${timeframe.value}: ${e.message}", e)
                         }
-                    } catch (e: Exception) {
-                        Log.e("ScreeningViewModel", "Erro ao processar ${asset.ticker}-${timeframe.value}: ${e.message}", e)
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,4 +76,5 @@
     <string name="last_price">Último Preço</string>
     <string name="change_percent">% Variação</string>
     <string name="view_chart">Ver gráfico</string>
+    <string name="no_patterns_found">Nenhum padrão encontrado.</string>
 </resources>

--- a/app/src/test/java/br/com/rodorush/chartpatterntracker/model/PatternDetectionTest.kt
+++ b/app/src/test/java/br/com/rodorush/chartpatterntracker/model/PatternDetectionTest.kt
@@ -23,7 +23,20 @@ class PatternDetectionTest {
         assertEquals(2, occurrences.size)
         occurrences.forEach { assertEquals(2, it.candles.size) }
     }
-}
+
+    @Test
+    fun detectBullishEngulfing_countsOccurrencesCorrectly() = runBlocking {
+        val candles = listOf(
+            Candlestick(time = 1L, open = 10f, high = 11f, low = 9f, close = 9.5f),
+            Candlestick(time = 2L, open = 9.4f, high = 10.5f, low = 9f, close = 10.8f)
+        )
+
+        val detector = br.com.rodorush.chartpatterntracker.model.pattern.BullishEngulfingDetector()
+        val occurrences = detector.detect(candles)
+
+        assertEquals(1, occurrences.size)
+        occurrences.forEach { assertEquals(2, it.candles.size) }
+    }
 
 fun detectHaramiAltaStandalone(candlesticks: List<Candlestick>): List<PatternOccurrence> {
     val occurrences = mutableListOf<PatternOccurrence>()
@@ -39,4 +52,5 @@ fun detectHaramiAltaStandalone(candlesticks: List<Candlestick>): List<PatternOcc
         }
     }
     return occurrences
+}
 }


### PR DESCRIPTION
## Summary
- create pattern detection API with registry
- implement Harami Alta and Bullish Engulfing detectors
- support multiple pattern detection in repository and view models
- allow passing pattern id to chart screen and navigation
- update screening workflow to loop over all selected patterns
- show generic no pattern message
- add unit test for bullish engulfing

## Testing
- `./gradlew test` *(fails: Task processing stops due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68697cbdd25883329bf92b301fd5a364