### PR TITLE
Add Bearish Engulfing detection and selection validation

### DIFF
--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/BearishEngulfingDetector.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/BearishEngulfingDetector.kt
@@ -1,0 +1,25 @@
+package br.com.rodorush.chartpatterntracker.model.pattern
+
+import br.com.rodorush.chartpatterntracker.model.Candlestick
+import br.com.rodorush.chartpatterntracker.model.PatternOccurrence
+
+/**
+ * Detects the Bearish Engulfing candlestick pattern.
+ */
+class BearishEngulfingDetector : PatternDetector {
+    override fun detect(candlesticks: List<Candlestick>): List<PatternOccurrence> {
+        val occurrences = mutableListOf<PatternOccurrence>()
+        if (candlesticks.size < 2) return occurrences
+        for (i in 1 until candlesticks.size) {
+            val current = candlesticks[i]
+            val previous = candlesticks[i - 1]
+            val prevBullish = previous.close > previous.open
+            val currBearish = current.close < current.open
+            val engulfs = current.open >= previous.close && current.close <= previous.open
+            if (prevBullish && currBearish && engulfs) {
+                occurrences.add(PatternOccurrence(listOf(previous, current)))
+            }
+        }
+        return occurrences
+    }
+}

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/HaramiAltaDetector.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/HaramiAltaDetector.kt
@@ -1,0 +1,22 @@
+package br.com.rodorush.chartpatterntracker.model.pattern
+
+import br.com.rodorush.chartpatterntracker.model.Candlestick
+import br.com.rodorush.chartpatterntracker.model.PatternOccurrence
+
+class HaramiAltaDetector : PatternDetector {
+    override fun detect(candlesticks: List<Candlestick>): List<PatternOccurrence> {
+        val occurrences = mutableListOf<PatternOccurrence>()
+        if (candlesticks.size < 2) return occurrences
+        for (i in 1 until candlesticks.size) {
+            val current = candlesticks[i]
+            val previous = candlesticks[i - 1]
+            val isBullish = current.close > current.open
+            val isBearish = previous.open > previous.close
+            val isContained = current.open > previous.close && current.close < previous.open
+            if (isBullish && isBearish && isContained) {
+                occurrences.add(PatternOccurrence(listOf(previous, current)))
+            }
+        }
+        return occurrences
+    }
+}

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/PatternDetector.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/PatternDetector.kt
@@ -1,0 +1,8 @@
+package br.com.rodorush.chartpatterntracker.model.pattern
+
+import br.com.rodorush.chartpatterntracker.model.Candlestick
+import br.com.rodorush.chartpatterntracker.model.PatternOccurrence
+
+interface PatternDetector {
+    fun detect(candlesticks: List<Candlestick>): List<PatternOccurrence>
+}

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/PatternDetectorRegistry.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/pattern/PatternDetectorRegistry.kt
@@ -1,0 +1,20 @@
+package br.com.rodorush.chartpatterntracker.model.pattern
+
+object PatternDetectorRegistry {
+    private val detectors = mutableMapOf<String, PatternDetector>()
+
+    init {
+        // Harami de Alta - document ID 48
+        register("48", HaramiAltaDetector())
+        // Bearish Engulfing pattern - document ID 9
+        register("9", BearishEngulfingDetector())
+    }
+
+    fun register(id: String, detector: PatternDetector) {
+        detectors[id] = detector
+    }
+
+    fun get(id: String): PatternDetector? = detectors[id]
+
+    fun registeredIds(): List<String> = detectors.keys.toList()
+}

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/AppNavHost.kt
@@ -78,7 +78,7 @@ fun AppNavHost(
                     onNavigateBack = { navController.popBackStack() },
                     onNextClick = { navController.navigate(Screen.SelectTimeframes.route) },
                     onChartClick = { ticker ->
-                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d", false))
+                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d", null, false))
                     }
                 )
             }
@@ -89,7 +89,7 @@ fun AppNavHost(
                 RealTimeQuotesScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onRowClick = { ticker ->
-                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d", false))
+                        navController.navigate(Screen.ChartDetail.createRoute(ticker, "1d", null, false))
                     }
                 )
             }
@@ -113,17 +113,18 @@ fun AppNavHost(
             ScreeningResultsScreen(
                 viewModel = screeningViewModel,
                 onNavigateBack = { navController.popBackStack() },
-                onCardClick = { ticker, timeframe ->
-                    navController.navigate(Screen.ChartDetail.createRoute(ticker, timeframe))
+                onCardClick = { ticker, timeframe, patternId ->
+                    navController.navigate(Screen.ChartDetail.createRoute(ticker, timeframe, patternId))
                 }
             )
         }
 
         composable(
-            Screen.ChartDetail.route + "/{ticker}/{timeframe}?detectPatterns={detectPatterns}",
+            Screen.ChartDetail.route + "/{ticker}/{timeframe}?patternId={patternId}&detectPatterns={detectPatterns}",
             arguments = listOf(
                 navArgument("ticker") { type = NavType.StringType },
                 navArgument("timeframe") { type = NavType.StringType },
+                navArgument("patternId") { type = NavType.StringType; defaultValue = "" },
                 navArgument("detectPatterns") {
                     type = NavType.BoolType
                     defaultValue = true
@@ -132,10 +133,12 @@ fun AppNavHost(
         ) { backStackEntry ->
             val ticker = backStackEntry.arguments?.getString("ticker") ?: ""
             val timeframe = backStackEntry.arguments?.getString("timeframe") ?: "1d"
+            val patternId = backStackEntry.arguments?.getString("patternId")?.takeIf { it.isNotEmpty() }
             val detectPatterns = backStackEntry.arguments?.getBoolean("detectPatterns") ?: true
             ChartDetailScreen(
                 ticker = ticker,
                 timeframe = timeframe,
+                patternId = patternId,
                 detectPatterns = detectPatterns,
                 onNavigateBack = { navController.popBackStack() }
             )

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/NavigationRoutes.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/navigation/NavigationRoutes.kt
@@ -10,8 +10,15 @@ sealed class Screen(val route: String) {
     object SelectTimeframes : Screen("select_timeframes")
     object ScreeningResults : Screen("screening_results")
     object ChartDetail : Screen("chart_detail") {
-        fun createRoute(ticker: String, timeframe: String, detectPatterns: Boolean = true) =
-            "chart_detail/$ticker/$timeframe?detectPatterns=$detectPatterns"
+        fun createRoute(
+            ticker: String,
+            timeframe: String,
+            patternId: String? = null,
+            detectPatterns: Boolean = true
+        ): String {
+            val idPart = patternId ?: ""
+            return "chart_detail/$ticker/$timeframe?patternId=$idPart&detectPatterns=$detectPatterns"
+        }
     }
     object RealTimeQuotes : Screen("real_time_quotes")
     object Settings : Screen("settings") // Nova rota para Settings

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ScreeningResultsScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ScreeningResultsScreen.kt
@@ -51,7 +51,7 @@ import br.com.rodorush.chartpatterntracker.viewmodel.ScreeningViewModel
 fun ScreeningResultsScreen(
     viewModel: ScreeningViewModel = viewModel(),
     onNavigateBack: () -> Unit = {},
-    onCardClick: (String, String) -> Unit = { _, _ -> }
+    onCardClick: (String, String, String) -> Unit = { _, _, _ -> }
 ) {
     Log.d("ScreeningResultsScreen", "Tela ScreeningResultsScreen carregada")
     // Coleta os resultados do ViewModel
@@ -121,7 +121,7 @@ fun ScreeningResultsScreen(
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
             } else if (screeningResults.isEmpty()) {
                 Text(
-                    text = "Nenhum padrão Harami de Alta encontrado.",
+                    text = stringResource(id = R.string.no_patterns_found),
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.align(Alignment.CenterHorizontally)
                 )
@@ -134,7 +134,7 @@ fun ScreeningResultsScreen(
                         Card(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable { onCardClick(result.asset.ticker, result.timeframe.value) }
+                                .clickable { onCardClick(result.asset.ticker, result.timeframe.value, result.pattern.id) }
                         ) {
                             Row(
                                 modifier = Modifier
@@ -195,6 +195,6 @@ fun ScreeningResultsScreen(
 @Composable
 fun ScreeningResultsScreenPreview() {
     ChartPatternTrackerTheme {
-        ScreeningResultsScreen()
+        ScreeningResultsScreen(onCardClick = { _, _, _ -> })
     }
 }

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectChartPatternScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectChartPatternScreen.kt
@@ -134,11 +134,14 @@ fun SelectChartPatternScreen(
                         Spacer(Modifier.width(4.dp))
                         Text(stringResource(R.string.home))
                     }
-                    Button(onClick = {
+                    Button(
+                        onClick = {
                         viewModel.updateSelectedPatterns(selected)
                         Log.d("SelectChartPatternScreen", "Botão Avançar clicado, padrões selecionados: ${selected.map { it.id to it.getLocalized("name") }}")
                         onNextClick()
-                    }) {
+                        },
+                        enabled = selected.isNotEmpty()
+                    ) {
                         Text(stringResource(R.string.next))
                         Spacer(Modifier.width(4.dp))
                         Icon(

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/util/provider/mock/MockPatternListProvider.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/util/provider/mock/MockPatternListProvider.kt
@@ -41,14 +41,14 @@ class MockPatternListProvider : PatternProvider {
         ),
         PatternItem(
             id = "3",
-            name = mapOf("pt" to "Engolfo de Alta", "en" to "Bullish Engulfing"),
+            name = mapOf("pt" to "Engolfo de Baixa", "en" to "Bearish Engulfing"),
             description = mapOf(
-                "pt" to "Um grande candle de alta engolfa completamente o candle de baixa anterior, sinalizando reversão.",
-                "en" to "A large bullish candle completely engulfs the previous bearish candle, signaling a reversal."
+                "pt" to "Um grande candle de baixa engolfa completamente o candle de alta anterior, sinalizando reversão.",
+                "en" to "A large bearish candle completely engulfs the previous bullish candle, signaling a reversal."
             ),
             indication = mapOf(
-                "pt" to "Reversão Altista",
-                "en" to "Bullish Reversal"
+                "pt" to "Reversão Baixista",
+                "en" to "Bearish Reversal"
             ),
             reliability = mapOf(
                 "pt" to "Alta",

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/viewmodel/ScreeningViewModel.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/viewmodel/ScreeningViewModel.kt
@@ -58,51 +58,51 @@ class ScreeningViewModel(
         viewModelScope.launch {
             _screeningResults.value = emptyList()
             val results = mutableListOf<ScreeningResult>()
-            val pattern = _selectedPatterns.value.firstOrNull { it.id == "48" }
-            if (pattern == null) {
-                Log.w("ScreeningViewModel", "Nenhum padrão Harami de Alta (ID 48) selecionado")
-                return@launch
-            }
-            Log.d("ScreeningViewModel", "Padrão Harami de Alta selecionado: ${pattern.id} - ${pattern.name}")
-
-            for (asset in _selectedAssets.value) {
-                for (timeframe in _selectedTimeframes.value) {
-                    try {
-                        Log.d("ScreeningViewModel", "Chamando fetchData para ticker=${asset.ticker}, timeframe=${timeframe.value}")
-                        val patternsDetected = withTimeoutOrNull(15000L) {
-                            chartViewModel.fetchData(asset.ticker, "3mo", timeframe.value)
-                            chartViewModel.isLoading.first { !it }
-                            chartViewModel.patternsData.first()
-                        }
-                        if (patternsDetected == null) {
-                            Log.e("ScreeningViewModel", "Timeout ao processar ${asset.ticker}-${timeframe.value}")
-                            continue
-                        }
-                        if (chartViewModel.error.value != null) {
-                            Log.e("ScreeningViewModel", "Erro retornado pelo ChartViewModel para ${asset.ticker}-${timeframe.value}: ${chartViewModel.error.value}")
-                            continue
-                        }
-                        Log.d("ScreeningViewModel", "Detectados ${patternsDetected.size} padrões Harami de Alta para ${asset.ticker}-${timeframe.value}")
-                        if (patternsDetected.isNotEmpty()) {
-                            val reliabilityText = pattern.getLocalized("reliability")
-                            val reliabilityStars = convertReliabilityToStars(reliabilityText)
-                            results.add(
-                                ScreeningResult(
-                                    pattern = pattern,
-                                    asset = asset,
-                                    timeframe = timeframe,
-                                    reliability = reliabilityStars,
-                                    indication = pattern.getLocalized("indication"),
-                                    indicationIcon = br.com.rodorush.chartpatterntracker.R.drawable.ic_up_arrow
+            for (pattern in _selectedPatterns.value) {
+                Log.d("ScreeningViewModel", "Processando padrão ${pattern.id}")
+                for (asset in _selectedAssets.value) {
+                    for (timeframe in _selectedTimeframes.value) {
+                        try {
+                            Log.d("ScreeningViewModel", "Chamando fetchData para ticker=${asset.ticker}, timeframe=${timeframe.value}")
+                            val patternsDetected = withTimeoutOrNull(15000L) {
+                                chartViewModel.fetchData(asset.ticker, "3mo", timeframe.value, true, listOf(pattern.id))
+                                chartViewModel.isLoading.first { !it }
+                                chartViewModel.patternsData.first()
+                            }
+                            if (patternsDetected == null) {
+                                Log.e("ScreeningViewModel", "Timeout ao processar ${asset.ticker}-${timeframe.value}")
+                                continue
+                            }
+                            if (chartViewModel.error.value != null) {
+                                Log.e(
+                                    "ScreeningViewModel",
+                                    "Erro retornado pelo ChartViewModel para ${asset.ticker}-${timeframe.value}: ${chartViewModel.error.value}"
                                 )
+                                continue
+                            }
+                            val occurrences = patternsDetected[pattern.id].orEmpty()
+                            Log.d(
+                                "ScreeningViewModel",
+                                "Detectados ${occurrences.size} padrões ${pattern.id} para ${asset.ticker}-${timeframe.value}"
                             )
-                            _screeningResults.value = results.toList()
-                            Log.d("ScreeningViewModel", "Resultado adicionado para ${asset.ticker}-${timeframe.value}")
-                        } else {
-                            Log.d("ScreeningViewModel", "Nenhum padrão Harami de Alta encontrado para ${asset.ticker}-${timeframe.value}")
+                            if (occurrences.isNotEmpty()) {
+                                val reliabilityText = pattern.getLocalized("reliability")
+                                val reliabilityStars = convertReliabilityToStars(reliabilityText)
+                                results.add(
+                                    ScreeningResult(
+                                        pattern = pattern,
+                                        asset = asset,
+                                        timeframe = timeframe,
+                                        reliability = reliabilityStars,
+                                        indication = pattern.getLocalized("indication"),
+                                        indicationIcon = br.com.rodorush.chartpatterntracker.R.drawable.ic_up_arrow
+                                    )
+                                )
+                                _screeningResults.value = results.toList()
+                            }
+                        } catch (e: Exception) {
+                            Log.e("ScreeningViewModel", "Erro ao processar ${asset.ticker}-${timeframe.value}: ${e.message}", e)
                         }
-                    } catch (e: Exception) {
-                        Log.e("ScreeningViewModel", "Erro ao processar ${asset.ticker}-${timeframe.value}: ${e.message}", e)
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,4 +76,5 @@
     <string name="last_price">Último Preço</string>
     <string name="change_percent">% Variação</string>
     <string name="view_chart">Ver gráfico</string>
+    <string name="no_patterns_found">Nenhum padrão encontrado.</string>
 </resources>

--- a/app/src/test/java/br/com/rodorush/chartpatterntracker/model/PatternDetectionTest.kt
+++ b/app/src/test/java/br/com/rodorush/chartpatterntracker/model/PatternDetectionTest.kt
@@ -23,7 +23,20 @@ class PatternDetectionTest {
         assertEquals(2, occurrences.size)
         occurrences.forEach { assertEquals(2, it.candles.size) }
     }
-}
+
+    @Test
+    fun detectBearishEngulfing_countsOccurrencesCorrectly() = runBlocking {
+        val candles = listOf(
+            Candlestick(time = 1L, open = 9f, high = 10.5f, low = 8.8f, close = 10f),
+            Candlestick(time = 2L, open = 10.2f, high = 10.4f, low = 8.5f, close = 8.8f)
+        )
+
+        val detector = br.com.rodorush.chartpatterntracker.model.pattern.BearishEngulfingDetector()
+        val occurrences = detector.detect(candles)
+
+        assertEquals(1, occurrences.size)
+        occurrences.forEach { assertEquals(2, it.candles.size) }
+    }
 
 fun detectHaramiAltaStandalone(candlesticks: List<Candlestick>): List<PatternOccurrence> {
     val occurrences = mutableListOf<PatternOccurrence>()
@@ -39,4 +52,5 @@ fun detectHaramiAltaStandalone(candlesticks: List<Candlestick>): List<PatternOcc
         }
     }
     return occurrences
+}
 }


### PR DESCRIPTION
## Summary
- implement `BearishEngulfingDetector` and register it (ID 9)
- remove default Harami pattern from `ChartViewModel.fetchData`
- disable "Next" button until a chart pattern is selected
- update mock pattern provider and tests for new detector

## Testing
- `./gradlew test` *(fails: Task processing stops due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68697cbdd25883329bf92b301fd5a364