### PR TITLE
Implement asset filtering

### DIFF
--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectAssetScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectAssetScreen.kt
@@ -62,8 +62,12 @@ fun SelectAssetsScreen(
 
     LaunchedEffect(Unit) {
         assetsProvider.fetchAssets { loadedAssets ->
-            assets = loadedAssets
-            Log.d("SelectAssetsScreen", "Ativos carregados: ${loadedAssets.map { it.ticker }}")
+            val filtered = loadedAssets.filterNot { it.ticker.endsWith("F", ignoreCase = true) }
+            assets = filtered
+            Log.d(
+                "SelectAssetsScreen",
+                "Ativos carregados: ${filtered.map { it.ticker }}"
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- filter out assets ending in `F` when listing them on SelectAssetScreen

## Testing
- `./gradlew test --no-daemon --continue`

------
https://chatgpt.com/codex/tasks/task_e_6870d031258c83329a3e3233acd582f2