### PR TITLE
Map indication to drawable icons

### DIFF
--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/model/ScreeningResult.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/model/ScreeningResult.kt
@@ -1,12 +1,10 @@
 package br.com.rodorush.chartpatterntracker.model
 
-import br.com.rodorush.chartpatterntracker.R
-
 data class ScreeningResult(
     val pattern: PatternItem,
     val asset: AssetItem,
     val timeframe: TimeframeItem,
     val reliability: String,
     val indication: String,
-    val indicationIcon: Int = R.drawable.ic_up_arrow
+    val indicationIcon: Int
 )

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/viewmodel/ScreeningViewModel.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/viewmodel/ScreeningViewModel.kt
@@ -95,14 +95,16 @@ class ScreeningViewModel(
                                 if (occurrences.isNotEmpty()) {
                                     val reliabilityText = pattern.getLocalized("reliability")
                                     val reliabilityStars = convertReliabilityToStars(reliabilityText)
+                                    val indicationText = pattern.getLocalized("indication")
+                                    val indicationIconRes = convertIndicationToIcon(indicationText)
                                     results.add(
                                         ScreeningResult(
                                             pattern = pattern,
                                             asset = asset,
                                             timeframe = timeframe,
                                             reliability = reliabilityStars,
-                                            indication = pattern.getLocalized("indication"),
-                                            indicationIcon = br.com.rodorush.chartpatterntracker.R.drawable.ic_up_arrow
+                                            indication = indicationText,
+                                            indicationIcon = indicationIconRes
                                         )
                                     )
                                     _screeningResults.value = results.toList()
@@ -132,6 +134,20 @@ class ScreeningViewModel(
             "média", "media", "medium" -> "★★"
             "alta", "high" -> "★★★"
             else -> reliability
+        }
+    }
+
+    private fun convertIndicationToIcon(indication: String): Int {
+        return when (indication.lowercase()) {
+            "reversão baixista", "bearish reversal", "reversión bajista" ->
+                br.com.rodorush.chartpatterntracker.R.drawable.reversao_baixista
+            "reversão altista", "bullish reversal", "reversión alcista" ->
+                br.com.rodorush.chartpatterntracker.R.drawable.reversao_altista
+            "continuação de baixa", "bearish continuation", "continuación bajista" ->
+                br.com.rodorush.chartpatterntracker.R.drawable.continuacao_baixa
+            "continuação de alta", "bullish continuation", "continuación alcista" ->
+                br.com.rodorush.chartpatterntracker.R.drawable.continuacao_alta
+            else -> br.com.rodorush.chartpatterntracker.R.drawable.ic_up_arrow
         }
     }
 }

--- a/app/src/main/res/drawable/continuacao_alta.xml
+++ b/app/src/main/res/drawable/continuacao_alta.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="8dp"
+    android:viewportWidth="158.51"
+    android:viewportHeight="79.25">
+  <path
+      android:fillColor="#FF008000"
+      android:pathData="M105.67,14.62l-53.84,52.98l8.48,8.48l52.78,-54.08l12.5,12.96l0,-31.79l-31.79,0z"/>
+  <path
+      android:pathData="M16.6,43.06h125.31v7.43h-125.31z"
+      android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/continuacao_baixa.xml
+++ b/app/src/main/res/drawable/continuacao_baixa.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="8dp"
+    android:viewportWidth="215.68"
+    android:viewportHeight="107.84">
+  <path
+      android:fillColor="#FFFF0000"
+      android:pathData="M143.78,87.95l-73.25,-72.1l11.54,-11.53l71.81,73.58l17.01,-17.63l0,43.25l-43.26,0z"/>
+  <path
+      android:pathData="M22.59,39.14h170.51v10.11h-170.51z"
+      android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/reversao_altista.xml
+++ b/app/src/main/res/drawable/reversao_altista.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="8dp"
+    android:viewportWidth="157.87"
+    android:viewportHeight="78.94">
+  <path
+      android:fillColor="#FF008000"
+      android:pathData="M25.32,48.29l9.49,-8.18l19.21,21.76l7.78,0l42.94,-44.02l-13.62,-13.42l35.1,0l0,33.58l-13.62,-12.48l-43.68,45.16l-21.86,0z"/>
+  <path
+      android:pathData="M16.53,70.81h124.81v7.4h-124.81z"
+      android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/reversao_baixista.xml
+++ b/app/src/main/res/drawable/reversao_baixista.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="8dp"
+    android:viewportWidth="218.05"
+    android:viewportHeight="109.02">
+  <path
+      android:fillColor="#FFFF0000"
+      android:pathData="M34.98,42.33l13.1,11.3l26.53,-30.06l10.74,0l59.32,60.8l-18.81,18.54l48.47,0l0,-46.39l-18.81,17.25l-60.33,-62.38l-30.19,0z"/>
+  <path
+      android:pathData="M22.83,1.01h172.38v10.22h-172.38z"
+      android:fillColor="#000000"/>
+</vector>


### PR DESCRIPTION
## Summary
- add mapping from indication text to drawable icons
- require indicationIcon when constructing `ScreeningResult`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687847be3b1c83329bb659aa0e67bf28