### PR TITLE
Use remote images for chart patterns

### DIFF
--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectChartPatternScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectChartPatternScreen.kt
@@ -1,7 +1,6 @@
 package br.com.rodorush.chartpatterntracker.ui.screen
 
 import android.util.Log
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -42,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -52,8 +52,11 @@ import br.com.rodorush.chartpatterntracker.R
 import br.com.rodorush.chartpatterntracker.model.PatternItem
 import br.com.rodorush.chartpatterntracker.ui.theme.ChartPatternTrackerTheme
 import br.com.rodorush.chartpatterntracker.util.LocalPatternProvider
+import br.com.rodorush.chartpatterntracker.util.loadImageUrlFromStorage
 import br.com.rodorush.chartpatterntracker.util.provider.mock.MockPatternListProvider
 import br.com.rodorush.chartpatterntracker.viewmodel.ScreeningViewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -189,8 +192,16 @@ fun SelectChartPatternScreen(
                             modifier = Modifier.weight(1f)
                         )
                         Spacer(modifier = Modifier.width(16.dp))
-                        Image(
-                            painter = painterResource(id = R.drawable.castical_64px),
+                        var imageUrl by remember { mutableStateOf<String?>(null) }
+                        LaunchedEffect(pattern.id) {
+                            imageUrl = loadImageUrlFromStorage(pattern.id)
+                        }
+                        AsyncImage(
+                            model = ImageRequest.Builder(LocalContext.current)
+                                .data(imageUrl)
+                                .crossfade(true)
+                                .build(),
+                            placeholder = painterResource(id = R.drawable.castical_64px),
                             contentDescription = stringResource(R.string.pattern_description),
                             modifier = Modifier
                                 .width(40.dp)


### PR DESCRIPTION
## Summary
- show pattern images loaded from Firebase storage in SelectChartPatternScreen

## Testing
- `./gradlew test` *(fails: checkDebugAarMetadata)*

------
https://chatgpt.com/codex/tasks/task_e_6878b8418de4833294aa6534c3944821