### PR TITLE
Lock app orientation to portrait

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
         <activity
             android:name=".activity.AuthenticationActivity"
             android:exported="true"
-            android:theme="@style/Theme.App.Starting">
+            android:theme="@style/Theme.App.Starting"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -31,6 +32,7 @@
         <activity
             android:name=".activity.MainActivity"
             android:exported="false"
-            android:theme="@style/Theme.ChartPatternTracker" />
+            android:theme="@style/Theme.ChartPatternTracker"
+            android:screenOrientation="portrait" />
     </application>
 </manifest>


### PR DESCRIPTION
## Summary
- enforce portrait orientation on AuthenticationActivity and MainActivity via AndroidManifest

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6878ba50d5f0833288548e4313f26ffb