### PR TITLE
Implement search filter in selection screens

### DIFF
--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectAssetScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectAssetScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
@@ -81,6 +81,11 @@ fun SelectAssetsScreen(
         }
     }
     var searchText by remember { mutableStateOf("") }
+    val filteredIndices = remember(searchText, assets) {
+        assets.mapIndexedNotNull { index, asset ->
+            if (asset.ticker.contains(searchText, ignoreCase = true)) index else null
+        }
+    }
     var allChecked by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -194,7 +199,8 @@ fun SelectAssetsScreen(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.weight(1f)
             ) {
-                itemsIndexed(assets) { index, asset ->
+                items(filteredIndices) { index ->
+                    val asset = assets[index]
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectChartPatternScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectChartPatternScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Home
@@ -85,6 +85,11 @@ fun SelectChartPatternScreen(
         }
     }
     var searchText by remember { mutableStateOf("") }
+    val filteredIndices = remember(searchText, patterns) {
+        patterns.mapIndexedNotNull { index, pattern ->
+            if (pattern.getLocalized("name").contains(searchText, ignoreCase = true)) index else null
+        }
+    }
     var allChecked by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -173,7 +178,8 @@ fun SelectChartPatternScreen(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.weight(1f)
             ) {
-                itemsIndexed(patterns) { index, pattern ->
+                items(filteredIndices) { index ->
+                    val pattern = patterns[index]
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectTimeFrameScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/SelectTimeFrameScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
@@ -29,6 +29,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -67,6 +68,17 @@ fun SelectTimeframesScreen(
         }
     }
     var searchText by remember { mutableStateOf("") }
+    val context = LocalContext.current
+    val filteredIndices = remember(searchText, timeframes, context) {
+        timeframes.mapIndexedNotNull { index, timeframe ->
+            val name = context.getString(timeframe.nameRes)
+            if (name.contains(searchText, ignoreCase = true) || timeframe.value.contains(searchText, ignoreCase = true)) {
+                index
+            } else {
+                null
+            }
+        }
+    }
     var allChecked by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -160,7 +172,8 @@ fun SelectTimeframesScreen(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.weight(1f)
             ) {
-                itemsIndexed(timeframes) { index, timeframe ->
+                items(filteredIndices) { index ->
+                    val timeframe = timeframes[index]
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()


### PR DESCRIPTION
## Summary
- add asset filtering to SelectAssetsScreen
- filter chart patterns in SelectChartPatternScreen
- search timeframes in SelectTimeframesScreen

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687b59a4a25c8332a95786949e4def83