### PR TITLE
Fix chart axis to show dates

### DIFF
--- a/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ChartDetailScreen.kt
+++ b/app/src/main/java/br/com/rodorush/chartpatterntracker/ui/screen/ChartDetailScreen.kt
@@ -231,7 +231,7 @@ fun List<Candlestick>.toJsonArray(highlightTimes: Set<Long> = emptySet()): Strin
     val jsonArray = JSONArray()
     for (item in this) {
         val jsonObject = JSONObject().apply {
-            put("time", item.time)
+            put("time", item.time / 1000)
             put("open", item.open)
             put("high", item.high)
             put("low", item.low)


### PR DESCRIPTION
## Summary
- convert `Candlestick.time` to seconds before sending JSON to chart so x-axis uses dates

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687b559933d48332aff02e3d65e52a21